### PR TITLE
Make plugin work, when linked into Kibana

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export default function (kibana) {
       hacks: [
         'plugins/enhanced-table/enhanced-table-vis-hack'
       ],
-      styleSheetPaths: resolve(__dirname, 'public/enhanced-table-vis.css')
+      styleSheetPaths: resolve('plugins/enhanced-table/public/enhanced-table-vis.css')
     }
   });
 


### PR DESCRIPTION
Hi @fbaligand ,
in my dev setup I tend to link plugins into my kibana/plugins folder and it turns out that this doesn't work with the this plugin, since `__dirname` will not resolve to the correct path. I created a small patch, which works in my environment. I only tested this in my environment and I hope this doesn't break under different circumstances. Please let me know what you think about it and whether I can maybe improve this pull request.
Thank you for the great plugin!