### PR TITLE
Replace hide_cols_by_index with hide_cols_by_label

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ This Kibana visualization plugin is like a Data Table, but with enhanced feature
   - More documentation [here](#computed-column-formula--lines-computed-filter-documentation)
 - Filter table lines based on a computed formula (ex: `col0 > 0`)
   - More documentation [here](#computed-column-formula--lines-computed-filter-documentation)
-- Hide some table columns (ex: `0,1` hides columns 0 and 1)
+- Hide some table columns (ex: `0,1,My_Column` hides columns 0, 1 and the column labeled 'My_Column')
+  - Note that the column label must be written as is (including whitespaces), without any superscript/apostrophe.
+  - Column labels containing commas are not supported since the comma is used to separate the columns
+  - It is strongly recommended to use column labels to hide columns rather than their indeces. Using the Split By Cols feature, in fact, indeces might   depend on the global timerange that has been set. 
 - Add a filter bar (ex: when user enters `cat` filter, it will display only rows that contain "cat")  
   - Works also with numeric and date columns
   - Ability to enable case sensitive filter
@@ -45,7 +48,7 @@ Every release package includes a Plugin version (X.Y.Z) and a Kibana version (A.
 
 - Go to [releases](https://github.com/fbaligand/kibana-enhanced-table/releases "Go to releases!") and choose the right one for your Kibana
 - launch a shell terminal and go to $KIBANA_HOME/bin folder
-- use Kibana CLI to install : 
+- use Kibana CLI to install :
   - directly from Internet URL :
 `$KIBANA_HOME/bin/kibana-plugin install https://github.com/fbaligand/kibana-enhanced-table/releases/download/vX.Y.Z/enhanced-table-X.Y.Z_A.B.C.zip`
   - locally after manual download :
@@ -62,7 +65,7 @@ Common features available for 'Computed Column Formula' and 'Lines Computed Filt
 - Column reference validation (by number or label), with error notification
 - Formula validation, with error notification
 - Additional custom functions listed in table below (ex: `col['Expiration Date'] > now() ? 'OK' : 'KO'`)
-  
+
 Function     | Description
 :----------- | :----------
 [now()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now)  | Returns the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This Kibana visualization plugin is like a Data Table, but with enhanced feature
 - Filter table lines based on a computed formula (ex: `col0 > 0`)
   - More documentation [here](#computed-column-formula--lines-computed-filter-documentation)
 - Hide some table columns (ex: `0,1,Col2 Label` hides columns 0, 1 and the column labeled 'Col2 Label')
-  - Note that the column label must be written as is (including whitespaces), without any superscript/apostrophe.
+  - Note that the column label must be written as is (including whitespaces), with no surrounding quotes.
   - Column labels containing commas are not supported since the comma is used to separate the columns
-  - It is strongly recommended to use column labels to hide columns rather than their indices. Using the 'Split cols' feature, in fact,     indices might depend on the global timerange that has been set. 
+  - It is recommended to use column labels to hide columns rather than their indices. Using the 'Split cols' feature, in fact, indices might depend on the global timerange that has been set. 
 - Add a filter bar (ex: when user enters `cat` filter, it will display only rows that contain "cat")  
   - Works also with numeric and date columns
   - Ability to enable case sensitive filter

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This Kibana visualization plugin is like a Data Table, but with enhanced feature
   - More documentation [here](#computed-column-formula--lines-computed-filter-documentation)
 - Filter table lines based on a computed formula (ex: `col0 > 0`)
   - More documentation [here](#computed-column-formula--lines-computed-filter-documentation)
-- Hide some table columns (ex: `0,1,My_Column` hides columns 0, 1 and the column labeled 'My_Column')
+- Hide some table columns (ex: `0,1,Col2 Label` hides columns 0, 1 and the column labeled 'Col2 Label')
   - Note that the column label must be written as is (including whitespaces), without any superscript/apostrophe.
   - Column labels containing commas are not supported since the comma is used to separate the columns
-  - It is strongly recommended to use column labels to hide columns rather than their indeces. Using the Split By Cols feature, in fact, indeces might   depend on the global timerange that has been set. 
+  - It is strongly recommended to use column labels to hide columns rather than their indices. Using the 'Split cols' feature, in fact,     indices might depend on the global timerange that has been set. 
 - Add a filter bar (ex: when user enters `cat` filter, it will display only rows that contain "cat")  
   - Works also with numeric and date columns
   - Ability to enable case sensitive filter

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -306,14 +306,20 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
         table.refRowWithHiddenCols = _.clone(table.rows[0]);
       }
 
-      let removedCounter = 0;
       _.forEach(hiddenColumns, function (item) {
-        let index = getRealColIndex(parseInt(item), splitColIndex);
-        table.columns.splice(index - removedCounter, 1);
-        _.forEach(table.rows, function (row) {
-          row.splice(index - removedCounter, 1);
-        });
-        removedCounter++;
+        try {
+          let itemIndex = findColIndexByTitle(table.columns, item, item, splitColIndex);
+          let index = getRealColIndex(itemIndex, splitColIndex);
+          table.columns.splice(index, 1);
+          _.forEach(table.rows, function (row) {
+            row.splice(index, 1);
+          });
+        } 
+        catch {
+          return;
+        }
+        
+        
       });
     });
   };

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -295,63 +295,10 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
     });
   };
 
-  // const fixUnsortedInput = (removedColumns, index) => {
-  //   let fixer = 0;
-  //   removedColumns.forEach(function (removedColumnIndex) {
-  //     if (removedColumnIndex > index) {
-  //       fixer++;
-  //     }
-  //   })
-  //   return fixer;
-  // };
-
   const isInt = (item) => {
     return /^ *[0-9]+ *$/.test(item);
   }
   
-
-  // const hideColumns = function (tables, hiddenColumns, splitColIndex) {
-  //   _.forEach(tables, function (table) {
-  //     if (table.tables) {
-  //       hideColumns(table.tables, hiddenColumns, splitColIndex);
-  //       return;
-  //     }
-
-  //     if (splitColIndex !== -1 && table.rows.length > 0) {
-  //       table.refRowWithHiddenCols = _.clone(table.rows[0]);
-  //     }
-
-  //     let removedCounter = 0;
-  //     let removedColumns = [];
-  //     _.forEach(hiddenColumns, function (item) {
-  //       try {
-  //         let index = isInt(item) ? getRealColIndex(parseInt(item), splitColIndex) : findColIndexByTitle(table.columns, item, item, splitColIndex);
-  //         if (index >= table.columns.length + removedCounter) {
-  //           return;
-  //         }
-  //         let colToRemove = index;
-  //         if (isInt(item)) {
-  //           if (removedColumns.includes(index)) return;
-  //           let indexFixer = fixUnsortedInput(removedColumns, index) - removedCounter;
-  //           colToRemove += indexFixer;
-  //           removedColumns.push(index)
-  //         } else {
-  //           if (removedColumns.includes(index + removedCounter)) return;
-  //           removedColumns.push(index + removedCounter)
-  //         }
-  //         table.columns.splice(colToRemove, 1);
-  //         _.forEach(table.rows, function (row) {
-  //           row.splice(colToRemove, 1);
-  //         });
-  //         removedCounter++;
-  //       } 
-  //       catch(e) {
-  //         return;
-  //       }     
-  //     });
-  //   });
-  // };
-
   const hideColumns = function (tables, hiddenColumns, splitColIndex) {
     // recursively call sub-tables
     _.forEach(tables, function (table) {

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -306,20 +306,32 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
         table.refRowWithHiddenCols = _.clone(table.rows[0]);
       }
 
+      let removedCounter = 0;
       _.forEach(hiddenColumns, function (item) {
         try {
-          let itemIndex = findColIndexByTitle(table.columns, item, item, splitColIndex);
-          let index = getRealColIndex(itemIndex, splitColIndex);
-          table.columns.splice(index, 1);
-          _.forEach(table.rows, function (row) {
-            row.splice(index, 1);
-          });
+          if (parseInt(item).toString() == item) {
+            let index = getRealColIndex(parseInt(item), splitColIndex);
+            let colToRemove = index - removedCounter;
+            console.log(colToRemove)
+            table.columns.splice(colToRemove, 1);
+            _.forEach(table.rows, function (row) {
+              row.splice(colToRemove, 1);
+            });
+            removedCounter++;
+          } else {
+            let itemIndex = findColIndexByTitle(table.columns, item, item, splitColIndex);
+            let index = getRealColIndex(itemIndex, splitColIndex);
+            let colToRemove = index;
+            console.log(colToRemove)
+            table.columns.splice(colToRemove, 1);
+            _.forEach(table.rows, function (row) {
+              row.splice(colToRemove, 1);
+            });
+          }
         } 
         catch {
           return;
-        }
-        
-        
+        }     
       });
     });
   };

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -345,7 +345,7 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
           });
           removedCounter++;
         } 
-        catch {
+        catch(e) {
           return;
         }     
       });

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -306,7 +306,7 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
   };
 
   const isInt = (item) => {
-    return /^[0-9]+$/.test(item);
+    return /^ *[0-9]+ *$/.test(item);
   }
   
 

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -331,10 +331,12 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
           }
           let colToRemove = index;
           if (isInt(item)) {
+            if (removedColumns.includes(index)) return;
             let indexFixer = fixUnsortedInput(removedColumns, index) - removedCounter;
             colToRemove += indexFixer;
             removedColumns.push(index)
           } else {
+            if (removedColumns.includes(index + removedCounter)) return;
             removedColumns.push(index + removedCounter)
           }
           table.columns.splice(colToRemove, 1);

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -306,7 +306,7 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
   };
 
   const isInt = (item) => {
-    return parseInt(item).toString() == item;
+    return /^[0-9]+$/.test(item);
   }
   
 

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -196,8 +196,8 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
     const FieldFormat = fieldFormats.getType(computedColumn.format);
     const fieldFormatParamsByFormat = {
       'string': {},
-      'number': {pattern: computedColumn.pattern},
-      'date': {pattern: computedColumn.datePattern}
+      'number': { pattern: computedColumn.pattern },
+      'date': { pattern: computedColumn.datePattern }
     };
     const fieldFormatParams = fieldFormatParamsByFormat[computedColumn.format];
     const aggSchema = (computedColumn.format === 'number') ? 'metric' : 'bucket';
@@ -206,7 +206,7 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
     // create new column object
     let newColumn = {
       id: `computed-col-${index}`,
-      aggConfig: new AggConfig($scope.vis.aggs, {schema: aggSchema, type: aggType}),
+      aggConfig: new AggConfig($scope.vis.aggs, { schema: aggSchema, type: aggType }),
       title: computedColumn.label,
       fieldFormatter: new FieldFormat(fieldFormatParams, getConfig),
       dataAlignmentClass: `text-${computedColumn.alignment}`,
@@ -297,8 +297,8 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
 
   const isInt = (item) => {
     return /^ *[0-9]+ *$/.test(item);
-  }
-  
+  };
+
   const hideColumns = function (tables, hiddenColumns, splitColIndex) {
     // recursively call sub-tables
     _.forEach(tables, function (table) {
@@ -508,7 +508,7 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
     let result = initialToString.call(this, contentType);
     if ($scope.filterHighlightRegex !== null && contentType === 'html') {
       if (typeof result === 'string') {
-        result = { 'markup': result};
+        result = { 'markup': result };
       }
       if (result.markup.indexOf('<span') === -1) {
         result.markup = `<span>${result.markup}</span>`;

--- a/public/enhanced-table-vis-controller.js
+++ b/public/enhanced-table-vis-controller.js
@@ -295,6 +295,21 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
     });
   };
 
+  const fixUnsortedInput = (removedColumns, index) => {
+    let fixer = 0;
+    removedColumns.forEach(function (removedColumnIndex) {
+      if (removedColumnIndex > index) {
+        fixer++;
+      }
+    })
+    return fixer;
+  };
+
+  const isInt = (item) => {
+    return parseInt(item).toString() == item;
+  }
+  
+
   const hideColumns = function (tables, hiddenColumns, splitColIndex) {
     _.forEach(tables, function (table) {
       if (table.tables) {
@@ -307,27 +322,26 @@ module.controller('EnhancedTableVisController', function ($scope, Private, confi
       }
 
       let removedCounter = 0;
+      let removedColumns = [];
       _.forEach(hiddenColumns, function (item) {
         try {
-          if (parseInt(item).toString() == item) {
-            let index = getRealColIndex(parseInt(item), splitColIndex);
-            let colToRemove = index - removedCounter;
-            console.log(colToRemove)
-            table.columns.splice(colToRemove, 1);
-            _.forEach(table.rows, function (row) {
-              row.splice(colToRemove, 1);
-            });
-            removedCounter++;
-          } else {
-            let itemIndex = findColIndexByTitle(table.columns, item, item, splitColIndex);
-            let index = getRealColIndex(itemIndex, splitColIndex);
-            let colToRemove = index;
-            console.log(colToRemove)
-            table.columns.splice(colToRemove, 1);
-            _.forEach(table.rows, function (row) {
-              row.splice(colToRemove, 1);
-            });
+          let index = isInt(item) ? getRealColIndex(parseInt(item), splitColIndex) : findColIndexByTitle(table.columns, item, item, splitColIndex);
+          if (index >= table.columns.length + removedCounter) {
+            return;
           }
+          let colToRemove = index;
+          if (isInt(item)) {
+            let indexFixer = fixUnsortedInput(removedColumns, index) - removedCounter;
+            colToRemove += indexFixer;
+            removedColumns.push(index)
+          } else {
+            removedColumns.push(index + removedCounter)
+          }
+          table.columns.splice(colToRemove, 1);
+          _.forEach(table.rows, function (row) {
+            row.splice(colToRemove, 1);
+          });
+          removedCounter++;
         } 
         catch {
           return;

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -190,8 +190,14 @@
 
     <div class="euiSpacer euiSpacer--s"></div>
     <div class="form-group">
-      <label>Hidden columns</label>
-      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="0,1,2,column_label_X..." />
+      <label>
+        Hidden columns
+        <icon-tip
+          content="'A column can be referenced by its index (e.g. 1,2,3..) or by its label (e.g. example_column,Example Column). It is important not to put any superscript or inverted comma if they are not part of the column label and to separate the columns to hide simply using a comma (labels containing commas cannot be hidden). References by id and by label can be mixed (e.g. 1,2,ExampleColumn) but it is strongly recommended to use the reference by label feature since indices may vary according to the timerange set.'"
+          position="'right'"
+        ></icon-tip>
+      </label>
+      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="0,1,2,Col2 Label,..." />
     </div>
 
     <div class="checkbox" ng-show="hasSplitColsBucket()">

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -191,7 +191,7 @@
     <div class="euiSpacer euiSpacer--s"></div>
     <div class="form-group">
       <label>Hidden columns</label>
-      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="0,1,..." />
+      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="column_name1,column_name2..." />
     </div>
 
     <div class="checkbox" ng-show="hasSplitColsBucket()">

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -191,7 +191,7 @@
     <div class="euiSpacer euiSpacer--s"></div>
     <div class="form-group">
       <label>Hidden columns</label>
-      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="column_name1,column_name2..." />
+      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="1,2,column_name_X..." />
     </div>
 
     <div class="checkbox" ng-show="hasSplitColsBucket()">

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -193,7 +193,7 @@
       <label>
         Hidden columns
         <icon-tip
-          content="'Reference a column by its index (1,2,3), by its label (Example Column) or both (1,2,column_3). Write the column label as is (no superscript or inverted commas) and divide them with a comma. It is recommended to reference a column by its label.'"
+          content="'Reference a column by its index (1,2,3), by its label (Example Column) or both (1,2,column_3). Write the column label as is (no surrounding quotes) and separate them using a comma. It is recommended to reference a column by its label.'"
           position="'right'"
         ></icon-tip>
       </label>

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -191,7 +191,7 @@
     <div class="euiSpacer euiSpacer--s"></div>
     <div class="form-group">
       <label>Hidden columns</label>
-      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="1,2,column_name_X..." />
+      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="0,1,2,column_label_X..." />
     </div>
 
     <div class="checkbox" ng-show="hasSplitColsBucket()">

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -193,11 +193,11 @@
       <label>
         Hidden columns
         <icon-tip
-          content="'A column can be referenced by its index (e.g. 1,2,3..) or by its label (e.g. example_column,Example Column). It is important not to put any superscript or inverted comma if they are not part of the column label and to separate the columns to hide simply using a comma (labels containing commas cannot be hidden). References by id and by label can be mixed (e.g. 1,2,ExampleColumn) but it is strongly recommended to use the reference by label feature since indices may vary according to the timerange set.'"
+          content="'Reference a column by its index (1,2,3), by its label (Example Column) or both (1,2,column_3). Write the column label as is (no superscript or inverted commas) and divide them with a comma. It is STRONGLY recommended to reference a column by its label.'"
           position="'right'"
         ></icon-tip>
       </label>
-      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="0,1,2,Col2 Label,..." />
+      <input type="text" ng-model="editorState.params.hiddenColumns" class="form-control" placeholder="0,1,Col2 Label,..." />
     </div>
 
     <div class="checkbox" ng-show="hasSplitColsBucket()">

--- a/public/enhanced-table-vis-params.html
+++ b/public/enhanced-table-vis-params.html
@@ -193,7 +193,7 @@
       <label>
         Hidden columns
         <icon-tip
-          content="'Reference a column by its index (1,2,3), by its label (Example Column) or both (1,2,column_3). Write the column label as is (no superscript or inverted commas) and divide them with a comma. It is STRONGLY recommended to reference a column by its label.'"
+          content="'Reference a column by its index (1,2,3), by its label (Example Column) or both (1,2,column_3). Write the column label as is (no superscript or inverted commas) and divide them with a comma. It is recommended to reference a column by its label.'"
           position="'right'"
         ></icon-tip>
       </label>


### PR DESCRIPTION
I introduced the possibility to hide a column by its label (simply specifying the labels separated by commas and without any superscript) and removed the possibility to hide it by its index since IMO it might be incredibly dangerous (if you use the split_by_cols feature, most likely you will have different number and types of columns depending on the global timerange filter). 

For the same reason, I added a try catch since if someone tries to hide a column that doesn't exist, I simply want the table to do nothing, not to throw an error and not showing anything (if I want to hide the column 'fabio' and I set a timerange where no event with field 'firstname'=='fabio' is present, I do not want the visualization to explode, but simply to do nothing about it). 

I obviously replaced the HiddenColumns placeholder, too.  

Personally, I suggest you should remove the possibility to directly reference a column by its index wholly, since it might be dangerous to do it even in the "Add computed columns" section. 